### PR TITLE
fix: remove lib-franklin from coverage

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,7 +1,23 @@
 const path = require('path');
+const istanbul = require('vite-plugin-istanbul');
+const constants = require('@storybook/addon-coverage/dist/cjs/constants');
+
 module.exports = {
   stories: ['../docs', '../blocks/**/*.mdx', '../blocks/**/*.stories.@(js|jsx|ts|tsx)', '../templates/**/*.stories.@(js|jsx|ts|tsx)', '../styles/system/stories/**/*.stories.@(js|jsx|ts|tsx)', '../styles/system/stories/**/*.mdx'],
-  addons: ['@storybook/addon-a11y', '@storybook/addon-links', '@storybook/addon-essentials', '@storybook/addon-interactions', '@storybook/addon-coverage', '@dylandepass/franklin-storybook-addon'],
+  addons: ['@storybook/addon-a11y', 
+           '@storybook/addon-links', 
+           '@storybook/addon-essentials', 
+           '@storybook/addon-interactions', 
+           '@dylandepass/franklin-storybook-addon', 
+           {
+              name: "@storybook/addon-coverage",
+              options: {
+                istanbul: {
+                  exclude: ['**/lib-franklin.js', '**/scripts.js']
+                },
+              },
+           },
+  ],
   framework: {
     name: '@storybook/html-vite',
     options: {},


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--rosalind-boilerplate--dylandepass.hlx.page/
- After: https://coverage--rosalind-boilerplate--dylandepass.hlx.page/
