### PR TITLE
fix: remove host from sidekick config

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,6 +1,5 @@
 {
   "project": "Rosalind",
-  "host": "rosalind.dylandepass.com",
   "plugins": [
     {
       "id": "library",


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--rosalind-boilerplate--dylandepass.hlx.page/
- After: https://remove-config-host--rosalind-boilerplate--dylandepass.hlx.page/
